### PR TITLE
Add auditing information for Docker builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,25 @@
 FROM rust:1.75-alpine3.19 AS builder
 ENV RUSTFLAGS="-C target-feature=-crt-static"
 RUN apk add --no-cache musl-dev
+RUN cargo install cargo-auditable
 WORKDIR /app
 COPY ./ /app
-RUN cargo build --release
+RUN cargo auditable build --release
 RUN strip target/release/crashie
 
 FROM alpine:3.19
 RUN apk add --no-cache libgcc
 COPY --from=builder /app/target/release/crashie .
 ENV PATH=$PATH:/
+
 ENTRYPOINT ["/crashie"]
 CMD ["--help"]
+
+ARG DESCRIPTION="A Command-Line Utility that exits with a random exit code after a configurable delay"
+LABEL org.opencontainers.image.title="crashie"
+LABEL org.opencontainers.image.description="$DESCRIPTION"
+LABEL org.opencontainers.artifact.description="$DESCRIPTION"
+LABEL org.opencontainers.image.documentation="https://github.com/sunsided/crashie"
+LABEL org.opencontainers.image.source="https://github.com/sunsided/crashie"
+LABEL org.label-schema.schema-version="1.0"
+LABEL org.label-schema.docker.cmd="docker run --rm -it sunside/crashie"

--- a/build-docker.sh
+++ b/build-docker.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DOCKER_IMAGE=sunside/crashie
+DOCKER_URL="https://hub.docker.com/r/$DOCKER_IMAGE"
+
+BUILD_DATE=$(date --rfc-3339=seconds | sed 's/ /T/')
+GIT_COMMIT_HASH=$(git rev-parse HEAD)
+APP_VERSION=$(sed -n 's/^version = "\(\S*\)\"$/\1/p' Cargo.toml)
+
+docker build --progress=plain --tag "$DOCKER_IMAGE" \
+  --label org.opencontainers.image.base.name="$DOCKER_IMAGE" \
+  --label org.opencontainers.image.url="$DOCKER_URL" \
+  --label org.opencontainers.artifact.created="$BUILD_DATE" \
+  --label org.opencontainers.image.created="$BUILD_DATE" \
+  --label org.opencontainers.image.authors="Markus Mayer" \
+  --label org.opencontainers.image.revision="$GIT_COMMIT_HASH" \
+  --label org.opencontainers.image.version="$APP_VERSION" \
+  -f Dockerfile .
+
+echo "Tagging image $DOCKER_IMAGE:latest as $DOCKER_IMAGE:$APP_VERSION"
+docker tag "$DOCKER_IMAGE:latest" "$DOCKER_IMAGE:$APP_VERSION"
+
+echo "Inspect labels using docker inspect $DOCKER_IMAGE:$APP_VERSION"


### PR DESCRIPTION
Uses cargo-auditable to produce auditable Docker builds.