### PR TITLE
Add TCP and UDP echo support

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -46,7 +46,7 @@ jobs:
         run: cargo clippy
 
   test:
-    name: Test ${{ matrix.rust }} on ${{ matrix.os }}
+    name: Test ${{ matrix.rust }} with  ${{ matrix.features }} on ${{ matrix.os }}
     needs:
       - style
     strategy:
@@ -81,7 +81,7 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
 
-      - name: Test with ${{ matrix.features }}
+      - name: Test
         run: cargo test --release ${{ matrix.features }}
 
   udeps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this project will be documented in this file.
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+- Added echo support for TCP connections via the `CRASHIE_BIND_TCP_ECHO` / `--bind-tcp-echo` option.
+- Added echo support for UDP datagrams via the `CRASHIE_BIND_UDP_ECHO` / `--bind-udp-echo` option.
+
 ## [0.2.0] - 2024-01-07
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -110,7 +110,7 @@ checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "crashie"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "clap",
  "dotenvy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,9 +12,10 @@ version = "0.2.0"
 edition = "2021"
 
 [features]
-default = ["posix", "non-posix"]
+default = ["posix", "non-posix", "tcp-echo"]
 posix = []
 non-posix = []
+tcp-echo = []
 
 [dependencies]
 clap = { version = "4.4.12", features = ["derive", "env"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,10 +12,11 @@ version = "0.2.0"
 edition = "2021"
 
 [features]
-default = ["posix", "non-posix", "tcp-echo"]
+default = ["posix", "non-posix", "tcp-echo", "udp-echo"]
 posix = []
 non-posix = []
 tcp-echo = []
+udp-echo = []
 
 [dependencies]
 clap = { version = "4.4.12", features = ["derive", "env"] }

--- a/README.md
+++ b/README.md
@@ -37,8 +37,6 @@ crashie --bind-tcp-echo 127.0.0.1:8080
 
 Likewise, UDP echo is supported. For that, use the `CRASHIE_BIND_UDP_ECHO` environment variable or run e.g.
 
-To bind crashie to TCP sockets, use the `CRASHIE_BIND_TCP_ECHO` environment variable or run e.g.
-
 ```bash
 crashie --bind-udp-echo 127.0.0.1:8080
 ```

--- a/README.md
+++ b/README.md
@@ -26,6 +26,25 @@ Alternatively, provide options using environment variables:
 CRASHIE_SIGNALS=2,3 CRASHIE_SLEEP_DELAY=10 CRASHIE_SLEEP_DELAY_STDDEV=2 crashie
 ```
 
+Crashie provides TCP and UDP echo functionalities. This comes in handy if you wand to test resilient connection
+logic, port forwarding (notably Kubernetes' `kubectl port-forward`) or similar aspects.
+
+To bind crashie to TCP sockets, use the `CRASHIE_BIND_TCP_ECHO` environment variable or run e.g.
+
+```bash
+crashie --bind-tcp-echo 127.0.0.1:8080
+```
+
+Likewise, UDP echo is supported. For that, use the `CRASHIE_BIND_UDP_ECHO` environment variable or run e.g.
+
+To bind crashie to TCP sockets, use the `CRASHIE_BIND_TCP_ECHO` environment variable or run e.g.
+
+```bash
+crashie --bind-udp-echo 127.0.0.1:8080
+```
+
+On Linux, you can test the echo behavior e.g. using netcat (`nc 127.0.0.1 8080` for TCP or `nc -u 127.0.0.1 8080` for UDP).
+
 ### Running via Docker
 
 The application is available as the [sunside/crashie](https://hub.docker.com/r/sunside/crashie) Docker image.

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,8 @@
 mod options;
 #[cfg(feature = "tcp-echo")]
 mod tcp_echo;
+#[cfg(feature = "udp-echo")]
+mod udp_echo;
 
 use clap::Parser;
 use dotenvy::dotenv;
@@ -19,11 +21,20 @@ fn main() {
     let mut rng = thread_rng();
     let opts: Opts = Opts::parse();
 
-    // Bind echo sockets.
+    // Bind TCP echo sockets.
     #[cfg(feature = "tcp-echo")]
     for addr in opts.tcp_echo_socks.iter().flatten() {
         if let Err(e) = tcp_echo::tcp_echo(addr) {
             eprintln!("Failed to bind to TCP socket: {e}");
+            exit(1);
+        }
+    }
+
+    // Bind TDP echo sockets.
+    #[cfg(feature = "udp-echo")]
+    for addr in opts.udp_echo_socks.iter().flatten() {
+        if let Err(e) = udp_echo::udp_echo(addr) {
+            eprintln!("Failed to bind to UDP socket: {e}");
             exit(1);
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,12 @@
 //! crashie — when you need it to fail.
 
+mod options;
+#[cfg(feature = "tcp-echo")]
+mod tcp_echo;
+
 use clap::Parser;
 use dotenvy::dotenv;
+use options::Opts;
 use rand::prelude::*;
 use rand_distr::Normal;
 use std::collections::HashSet;
@@ -9,276 +14,19 @@ use std::process::exit;
 use std::thread::sleep;
 use std::time::Duration;
 
-#[derive(Debug, Parser)]
-#[command(author, version, about, long_about = None)]
-struct Opts {
-    #[clap(
-        short = 'd',
-        long = "delay",
-        help = "The sleep duration before exiting, in seconds",
-        value_name = "SECONDS",
-        allow_negative_numbers = false,
-        default_value = "10.0",
-        value_parser(parse_seconds),
-        env = "CRASHIE_SLEEP_DELAY"
-    )]
-    sleep_delay: f64,
-    #[clap(
-        long = "delay-stddev",
-        help = "The standard deviation of the sleep duration, in seconds",
-        value_name = "SECONDS",
-        allow_negative_numbers = false,
-        default_value = "2.0",
-        value_parser(parse_seconds),
-        env = "CRASHIE_SLEEP_DELAY_STDDEV"
-    )]
-    sleep_delay_stddev: f64,
-    #[clap(
-        short = 'e',
-        long = "exit-code",
-        use_value_delimiter(true),
-        allow_negative_numbers = false,
-        help = "Exit with the specified code(s)",
-        env = "CRASHIE_EXIT_CODES"
-    )]
-    exit_codes: Vec<u8>,
-    #[clap(
-        short = 's',
-        long = "signals",
-        use_value_delimiter(true),
-        value_parser(parse_signal),
-        value_name = "NUMBER",
-        allow_negative_numbers = false,
-        help = "Arbitrary signal (exit code 128+SIGNAL)",
-        env = "CRASHIE_SIGNALS"
-    )]
-    signal: Vec<u8>,
-    #[cfg_attr(
-        feature = "posix",
-        clap(
-            long = "sighup",
-            help = "Hang up controlling terminal or terminal",
-            env = "CRASHIE_SIGHUP"
-        )
-    )]
-    sighup: bool,
-    #[cfg_attr(
-        feature = "posix",
-        clap(
-            long = "sigint",
-            help = "Interrupt from keyboard, Control-C",
-            env = "CRASHIE_SIGINT"
-        )
-    )]
-    sigint: bool,
-    #[cfg_attr(
-        feature = "posix",
-        clap(
-            long = "sigquit",
-            help = "Quit from keyboard, Control-\\",
-            env = "CRASHIE_SIGQUIT"
-        )
-    )]
-    sigquit: bool,
-    #[cfg_attr(
-        feature = "posix",
-        clap(long = "sigill", help = "Illegal instruction", env = "CRASHIE_SIGILL")
-    )]
-    sigill: bool,
-    #[cfg_attr(
-        feature = "non-posix",
-        clap(
-            long = "sigtrap",
-            help = "Breakpoint for debugging",
-            env = "CRASHIE_SIGTRAP"
-        )
-    )]
-    sigtrap: bool,
-    #[cfg_attr(
-        feature = "posix",
-        clap(
-            long = "sigabrt",
-            help = "Abnormal termination",
-            env = "CRASHIE_SIGABRT"
-        )
-    )]
-    sigabrt: bool,
-    #[cfg_attr(
-        feature = "non-posix",
-        clap(
-            long = "sigiot",
-            help = "Equivalent to SIGABRT",
-            env = "CRASHIE_SIGIOT"
-        )
-    )]
-    sigiot: bool,
-    #[cfg_attr(
-        feature = "non-posix",
-        clap(long = "sigbus", help = "Bus error", env = "CRASHIE_SIGBUS")
-    )]
-    sigbus: bool,
-    #[cfg_attr(
-        feature = "posix",
-        clap(
-            long = "sigfpe",
-            help = "Floating-point exception",
-            env = "CRASHIE_SIGFPE"
-        )
-    )]
-    sigfpe: bool,
-    #[cfg_attr(
-        feature = "posix",
-        clap(
-            long = "sigkill",
-            help = "Forced process termination",
-            env = "CRASHIE_SIGKILL"
-        )
-    )]
-    sigkill: bool,
-    #[cfg_attr(
-        feature = "posix",
-        clap(
-            long = "sigusr1",
-            help = "Freely available to processes",
-            env = "CRASHIE_SIGUSR1"
-        )
-    )]
-    sigusr1: bool,
-    #[cfg_attr(
-        feature = "posix",
-        clap(
-            long = "sigsegv",
-            help = "Invalid memory reference (Segmentation Fault)",
-            env = "CRASHIE_SIGSEGV"
-        )
-    )]
-    sigsegv: bool,
-    #[cfg_attr(
-        feature = "posix",
-        clap(
-            long = "sigusr2",
-            help = "Freely available to processes",
-            env = "CRASHIE_SIGUSR2"
-        )
-    )]
-    sigusr2: bool,
-    #[cfg_attr(
-        feature = "posix",
-        clap(
-            long = "sigpipe",
-            help = "Write to pipe with no readers",
-            env = "CRASHIE_SIGPIPE"
-        )
-    )]
-    sigpipe: bool,
-    #[cfg_attr(
-        feature = "posix",
-        clap(long = "sigalrm", help = "Real-time clock", env = "CRASHIE_SIGALRM")
-    )]
-    sigalrm: bool,
-    #[cfg_attr(
-        feature = "posix",
-        clap(
-            long = "sigterm",
-            help = "Process termination",
-            env = "CRASHIE_SIGTERM"
-        )
-    )]
-    sigterm: bool,
-    #[cfg_attr(
-        feature = "non-posix",
-        clap(
-            long = "sigstkflt",
-            help = "Coprocessor stack error",
-            env = "CRASHIE_SIGSTKFLT"
-        )
-    )]
-    sigstkflt: bool,
-    #[cfg_attr(
-        feature = "non-posix",
-        clap(
-            long = "sigchld",
-            help = "Child process stopped, terminated or got a signal if traced",
-            env = "CRASHIE_SIGCHLD"
-        )
-    )]
-    sigchld: bool,
-    #[cfg_attr(
-        feature = "non-posix",
-        clap(
-            long = "sigxcpu",
-            help = "CPU time limit exceeded",
-            env = "CRASHIE_SIGXCPU"
-        )
-    )]
-    sigxcpu: bool,
-    #[cfg_attr(
-        feature = "non-posix",
-        clap(
-            long = "sigxfsz",
-            help = "File size limit exceeded",
-            env = "CRASHIE_SIGXFSZ"
-        )
-    )]
-    sigxfsz: bool,
-    #[cfg_attr(
-        feature = "non-posix",
-        clap(
-            long = "sigvtalrm",
-            help = "Virtual timer clock",
-            env = "CRASHIE_SIGVTALRM"
-        )
-    )]
-    sigvtalrm: bool,
-    #[cfg_attr(
-        feature = "non-posix",
-        clap(
-            long = "sigprof",
-            help = "Profile timer clock",
-            env = "CRASHIE_SIGPROF"
-        )
-    )]
-    sigprof: bool,
-    #[cfg_attr(
-        feature = "non-posix",
-        clap(long = "sigio", help = "I/O now possible", env = "CRASHIE_SIGIO")
-    )]
-    sigio: bool,
-    #[cfg_attr(
-        feature = "non-posix",
-        clap(
-            long = "sigpoll",
-            help = "Equivalent to SIGIO",
-            env = "CRASHIE_SIGPOLL"
-        )
-    )]
-    sigpoll: bool,
-    #[cfg_attr(
-        feature = "non-posix",
-        clap(long = "sigpwr", help = "Power supply failure", env = "CRASHIE_SIGPWR")
-    )]
-    sigpwr: bool,
-    #[cfg_attr(
-        feature = "non-posix",
-        clap(long = "sigsys", help = "Bad system call", env = "CRASHIE_SIGSYS")
-    )]
-    sigsys: bool,
-    #[cfg_attr(
-        feature = "non-posix",
-        clap(
-            long = "sigunused",
-            help = "Equivalent to SIGSYS",
-            env = "CRASHIE_SIGUNUSED"
-        )
-    )]
-    sigunused: bool,
-}
-
 fn main() {
     dotenv().ok();
     let mut rng = thread_rng();
-
     let opts: Opts = Opts::parse();
+
+    // Bind echo sockets.
+    #[cfg(feature = "tcp-echo")]
+    for addr in opts.tcp_echo_socks.iter().flatten() {
+        if let Err(e) = tcp_echo::tcp_echo(addr) {
+            eprintln!("Failed to bind to TCP socket: {e}");
+            exit(1);
+        }
+    }
 
     let sleep_delay_mean = opts.sleep_delay;
     let sleep_delay_stddev = opts.sleep_delay_stddev;
@@ -399,24 +147,6 @@ fn add_signals(opts: Opts, codes: &mut HashSet<u8>) {
     }
     if opts.sigsys || opts.sigunused {
         codes.insert(signal_to_exit(31));
-    }
-}
-
-fn parse_signal(input: &str) -> Result<u8, String> {
-    let signal: u8 = input.parse().map_err(|e| format!("{e}"))?;
-    if !(1..=31).contains(&signal) {
-        Err(String::from("Signals must be in range 1 to 31 (inclusive)"))
-    } else {
-        Ok(signal)
-    }
-}
-
-fn parse_seconds(input: &str) -> Result<f64, String> {
-    let value: f64 = input.parse().map_err(|e| format!("{e}"))?;
-    if value < 0.0 {
-        Err(String::from("Value must be a non-negative number"))
-    } else {
-        Ok(value)
     }
 }
 

--- a/src/options.rs
+++ b/src/options.rs
@@ -1,0 +1,304 @@
+use clap::Parser;
+use std::net::{SocketAddr, ToSocketAddrs};
+
+#[derive(Debug, Parser)]
+#[command(author, version, about, long_about = None)]
+pub struct Opts {
+    #[clap(
+        short = 'd',
+        long = "delay",
+        help = "The sleep duration before exiting, in seconds",
+        value_name = "SECONDS",
+        allow_negative_numbers = false,
+        default_value = "10.0",
+        value_parser(parse_seconds),
+        env = "CRASHIE_SLEEP_DELAY"
+    )]
+    pub sleep_delay: f64,
+    #[clap(
+        long = "delay-stddev",
+        help = "The standard deviation of the sleep duration, in seconds",
+        value_name = "SECONDS",
+        allow_negative_numbers = false,
+        default_value = "2.0",
+        value_parser(parse_seconds),
+        env = "CRASHIE_SLEEP_DELAY_STDDEV"
+    )]
+    pub sleep_delay_stddev: f64,
+    #[cfg_attr(
+        feature = "tcp-echo",
+        clap(
+            long = "bind-tcp-echo",
+            help = "Binds an echo TCP socket on the specified addresses",
+            use_value_delimiter(true),
+            value_parser(parse_socket_addr),
+            env = "CRASHIE_BIND_TCP_ECHO"
+        )
+    )]
+    pub tcp_echo_socks: Vec<Vec<SocketAddr>>,
+    #[clap(
+        short = 'e',
+        long = "exit-code",
+        use_value_delimiter(true),
+        allow_negative_numbers = false,
+        help = "Exit with the specified code(s)",
+        env = "CRASHIE_EXIT_CODES"
+    )]
+    pub exit_codes: Vec<u8>,
+    #[clap(
+        short = 's',
+        long = "signals",
+        use_value_delimiter(true),
+        value_parser(parse_signal),
+        value_name = "NUMBER",
+        allow_negative_numbers = false,
+        help = "Arbitrary signal (exit code 128+SIGNAL)",
+        env = "CRASHIE_SIGNALS"
+    )]
+    pub signal: Vec<u8>,
+    #[cfg_attr(
+        feature = "posix",
+        clap(
+            long = "sighup",
+            help = "Hang up controlling terminal or terminal",
+            env = "CRASHIE_SIGHUP"
+        )
+    )]
+    pub sighup: bool,
+    #[cfg_attr(
+        feature = "posix",
+        clap(
+            long = "sigint",
+            help = "Interrupt from keyboard, Control-C",
+            env = "CRASHIE_SIGINT"
+        )
+    )]
+    pub sigint: bool,
+    #[cfg_attr(
+        feature = "posix",
+        clap(
+            long = "sigquit",
+            help = "Quit from keyboard, Control-\\",
+            env = "CRASHIE_SIGQUIT"
+        )
+    )]
+    pub sigquit: bool,
+    #[cfg_attr(
+        feature = "posix",
+        clap(long = "sigill", help = "Illegal instruction", env = "CRASHIE_SIGILL")
+    )]
+    pub sigill: bool,
+    #[cfg_attr(
+        feature = "non-posix",
+        clap(
+            long = "sigtrap",
+            help = "Breakpoint for debugging",
+            env = "CRASHIE_SIGTRAP"
+        )
+    )]
+    pub sigtrap: bool,
+    #[cfg_attr(
+        feature = "posix",
+        clap(
+            long = "sigabrt",
+            help = "Abnormal termination",
+            env = "CRASHIE_SIGABRT"
+        )
+    )]
+    pub sigabrt: bool,
+    #[cfg_attr(
+        feature = "non-posix",
+        clap(
+            long = "sigiot",
+            help = "Equivalent to SIGABRT",
+            env = "CRASHIE_SIGIOT"
+        )
+    )]
+    pub sigiot: bool,
+    #[cfg_attr(
+        feature = "non-posix",
+        clap(long = "sigbus", help = "Bus error", env = "CRASHIE_SIGBUS")
+    )]
+    pub sigbus: bool,
+    #[cfg_attr(
+        feature = "posix",
+        clap(
+            long = "sigfpe",
+            help = "Floating-point exception",
+            env = "CRASHIE_SIGFPE"
+        )
+    )]
+    pub sigfpe: bool,
+    #[cfg_attr(
+        feature = "posix",
+        clap(
+            long = "sigkill",
+            help = "Forced process termination",
+            env = "CRASHIE_SIGKILL"
+        )
+    )]
+    pub sigkill: bool,
+    #[cfg_attr(
+        feature = "posix",
+        clap(
+            long = "sigusr1",
+            help = "Freely available to processes",
+            env = "CRASHIE_SIGUSR1"
+        )
+    )]
+    pub sigusr1: bool,
+    #[cfg_attr(
+        feature = "posix",
+        clap(
+            long = "sigsegv",
+            help = "Invalid memory reference (Segmentation Fault)",
+            env = "CRASHIE_SIGSEGV"
+        )
+    )]
+    pub sigsegv: bool,
+    #[cfg_attr(
+        feature = "posix",
+        clap(
+            long = "sigusr2",
+            help = "Freely available to processes",
+            env = "CRASHIE_SIGUSR2"
+        )
+    )]
+    pub sigusr2: bool,
+    #[cfg_attr(
+        feature = "posix",
+        clap(
+            long = "sigpipe",
+            help = "Write to pipe with no readers",
+            env = "CRASHIE_SIGPIPE"
+        )
+    )]
+    pub sigpipe: bool,
+    #[cfg_attr(
+        feature = "posix",
+        clap(long = "sigalrm", help = "Real-time clock", env = "CRASHIE_SIGALRM")
+    )]
+    pub sigalrm: bool,
+    #[cfg_attr(
+        feature = "posix",
+        clap(
+            long = "sigterm",
+            help = "Process termination",
+            env = "CRASHIE_SIGTERM"
+        )
+    )]
+    pub sigterm: bool,
+    #[cfg_attr(
+        feature = "non-posix",
+        clap(
+            long = "sigstkflt",
+            help = "Coprocessor stack error",
+            env = "CRASHIE_SIGSTKFLT"
+        )
+    )]
+    pub sigstkflt: bool,
+    #[cfg_attr(
+        feature = "non-posix",
+        clap(
+            long = "sigchld",
+            help = "Child process stopped, terminated or got a signal if traced",
+            env = "CRASHIE_SIGCHLD"
+        )
+    )]
+    pub sigchld: bool,
+    #[cfg_attr(
+        feature = "non-posix",
+        clap(
+            long = "sigxcpu",
+            help = "CPU time limit exceeded",
+            env = "CRASHIE_SIGXCPU"
+        )
+    )]
+    pub sigxcpu: bool,
+    #[cfg_attr(
+        feature = "non-posix",
+        clap(
+            long = "sigxfsz",
+            help = "File size limit exceeded",
+            env = "CRASHIE_SIGXFSZ"
+        )
+    )]
+    pub sigxfsz: bool,
+    #[cfg_attr(
+        feature = "non-posix",
+        clap(
+            long = "sigvtalrm",
+            help = "Virtual timer clock",
+            env = "CRASHIE_SIGVTALRM"
+        )
+    )]
+    pub sigvtalrm: bool,
+    #[cfg_attr(
+        feature = "non-posix",
+        clap(
+            long = "sigprof",
+            help = "Profile timer clock",
+            env = "CRASHIE_SIGPROF"
+        )
+    )]
+    pub sigprof: bool,
+    #[cfg_attr(
+        feature = "non-posix",
+        clap(long = "sigio", help = "I/O now possible", env = "CRASHIE_SIGIO")
+    )]
+    pub sigio: bool,
+    #[cfg_attr(
+        feature = "non-posix",
+        clap(
+            long = "sigpoll",
+            help = "Equivalent to SIGIO",
+            env = "CRASHIE_SIGPOLL"
+        )
+    )]
+    pub sigpoll: bool,
+    #[cfg_attr(
+        feature = "non-posix",
+        clap(long = "sigpwr", help = "Power supply failure", env = "CRASHIE_SIGPWR")
+    )]
+    pub sigpwr: bool,
+    #[cfg_attr(
+        feature = "non-posix",
+        clap(long = "sigsys", help = "Bad system call", env = "CRASHIE_SIGSYS")
+    )]
+    pub sigsys: bool,
+    #[cfg_attr(
+        feature = "non-posix",
+        clap(
+            long = "sigunused",
+            help = "Equivalent to SIGSYS",
+            env = "CRASHIE_SIGUNUSED"
+        )
+    )]
+    pub sigunused: bool,
+}
+
+fn parse_signal(input: &str) -> Result<u8, String> {
+    let signal: u8 = input.parse().map_err(|e| format!("{e}"))?;
+    if !(1..=31).contains(&signal) {
+        Err(String::from("Signals must be in range 1 to 31 (inclusive)"))
+    } else {
+        Ok(signal)
+    }
+}
+
+fn parse_seconds(input: &str) -> Result<f64, String> {
+    let value: f64 = input.parse().map_err(|e| format!("{e}"))?;
+    if value < 0.0 {
+        Err(String::from("Value must be a non-negative number"))
+    } else {
+        Ok(value)
+    }
+}
+
+fn parse_socket_addr(input: &str) -> Result<Vec<SocketAddr>, String> {
+    Ok(input
+        .to_socket_addrs()
+        .map_err(|e| format!("{e}"))?
+        .into_iter()
+        .collect())
+}

--- a/src/options.rs
+++ b/src/options.rs
@@ -36,6 +36,17 @@ pub struct Opts {
         )
     )]
     pub tcp_echo_socks: Vec<Vec<SocketAddr>>,
+    #[cfg_attr(
+        feature = "udp-echo",
+        clap(
+            long = "bind-udp-echo",
+            help = "Binds an echo UDP socket on the specified addresses",
+            use_value_delimiter(true),
+            value_parser(parse_socket_addr),
+            env = "CRASHIE_BIND_UDP_ECHO"
+        )
+    )]
+    pub udp_echo_socks: Vec<Vec<SocketAddr>>,
     #[clap(
         short = 'e',
         long = "exit-code",
@@ -299,6 +310,5 @@ fn parse_socket_addr(input: &str) -> Result<Vec<SocketAddr>, String> {
     Ok(input
         .to_socket_addrs()
         .map_err(|e| format!("{e}"))?
-        .into_iter()
         .collect())
 }

--- a/src/options.rs
+++ b/src/options.rs
@@ -1,5 +1,5 @@
 use clap::Parser;
-use std::net::{SocketAddr, ToSocketAddrs};
+use std::net::SocketAddr;
 
 #[derive(Debug, Parser)]
 #[command(author, version, about, long_about = None)]
@@ -35,6 +35,7 @@ pub struct Opts {
             env = "CRASHIE_BIND_TCP_ECHO"
         )
     )]
+    #[cfg_attr(not(feature = "tcp-echo"), clap(skip))]
     pub tcp_echo_socks: Vec<Vec<SocketAddr>>,
     #[cfg_attr(
         feature = "udp-echo",
@@ -46,6 +47,7 @@ pub struct Opts {
             env = "CRASHIE_BIND_UDP_ECHO"
         )
     )]
+    #[cfg_attr(not(feature = "udp-echo"), clap(skip))]
     pub udp_echo_socks: Vec<Vec<SocketAddr>>,
     #[clap(
         short = 'e',
@@ -75,6 +77,7 @@ pub struct Opts {
             env = "CRASHIE_SIGHUP"
         )
     )]
+    #[cfg_attr(not(feature = "posix"), clap(skip))]
     pub sighup: bool,
     #[cfg_attr(
         feature = "posix",
@@ -84,6 +87,7 @@ pub struct Opts {
             env = "CRASHIE_SIGINT"
         )
     )]
+    #[cfg_attr(not(feature = "posix"), clap(skip))]
     pub sigint: bool,
     #[cfg_attr(
         feature = "posix",
@@ -93,11 +97,13 @@ pub struct Opts {
             env = "CRASHIE_SIGQUIT"
         )
     )]
+    #[cfg_attr(not(feature = "posix"), clap(skip))]
     pub sigquit: bool,
     #[cfg_attr(
         feature = "posix",
         clap(long = "sigill", help = "Illegal instruction", env = "CRASHIE_SIGILL")
     )]
+    #[cfg_attr(not(feature = "posix"), clap(skip))]
     pub sigill: bool,
     #[cfg_attr(
         feature = "non-posix",
@@ -107,6 +113,7 @@ pub struct Opts {
             env = "CRASHIE_SIGTRAP"
         )
     )]
+    #[cfg_attr(not(feature = "non-posix"), clap(skip))]
     pub sigtrap: bool,
     #[cfg_attr(
         feature = "posix",
@@ -116,6 +123,7 @@ pub struct Opts {
             env = "CRASHIE_SIGABRT"
         )
     )]
+    #[cfg_attr(not(feature = "posix"), clap(skip))]
     pub sigabrt: bool,
     #[cfg_attr(
         feature = "non-posix",
@@ -125,11 +133,13 @@ pub struct Opts {
             env = "CRASHIE_SIGIOT"
         )
     )]
+    #[cfg_attr(not(feature = "non-posix"), clap(skip))]
     pub sigiot: bool,
     #[cfg_attr(
         feature = "non-posix",
         clap(long = "sigbus", help = "Bus error", env = "CRASHIE_SIGBUS")
     )]
+    #[cfg_attr(not(feature = "non-posix"), clap(skip))]
     pub sigbus: bool,
     #[cfg_attr(
         feature = "posix",
@@ -139,6 +149,7 @@ pub struct Opts {
             env = "CRASHIE_SIGFPE"
         )
     )]
+    #[cfg_attr(not(feature = "posix"), clap(skip))]
     pub sigfpe: bool,
     #[cfg_attr(
         feature = "posix",
@@ -148,6 +159,7 @@ pub struct Opts {
             env = "CRASHIE_SIGKILL"
         )
     )]
+    #[cfg_attr(not(feature = "posix"), clap(skip))]
     pub sigkill: bool,
     #[cfg_attr(
         feature = "posix",
@@ -157,6 +169,7 @@ pub struct Opts {
             env = "CRASHIE_SIGUSR1"
         )
     )]
+    #[cfg_attr(not(feature = "posix"), clap(skip))]
     pub sigusr1: bool,
     #[cfg_attr(
         feature = "posix",
@@ -166,6 +179,7 @@ pub struct Opts {
             env = "CRASHIE_SIGSEGV"
         )
     )]
+    #[cfg_attr(not(feature = "posix"), clap(skip))]
     pub sigsegv: bool,
     #[cfg_attr(
         feature = "posix",
@@ -175,6 +189,7 @@ pub struct Opts {
             env = "CRASHIE_SIGUSR2"
         )
     )]
+    #[cfg_attr(not(feature = "posix"), clap(skip))]
     pub sigusr2: bool,
     #[cfg_attr(
         feature = "posix",
@@ -184,11 +199,13 @@ pub struct Opts {
             env = "CRASHIE_SIGPIPE"
         )
     )]
+    #[cfg_attr(not(feature = "posix"), clap(skip))]
     pub sigpipe: bool,
     #[cfg_attr(
         feature = "posix",
         clap(long = "sigalrm", help = "Real-time clock", env = "CRASHIE_SIGALRM")
     )]
+    #[cfg_attr(not(feature = "posix"), clap(skip))]
     pub sigalrm: bool,
     #[cfg_attr(
         feature = "posix",
@@ -198,6 +215,7 @@ pub struct Opts {
             env = "CRASHIE_SIGTERM"
         )
     )]
+    #[cfg_attr(not(feature = "posix"), clap(skip))]
     pub sigterm: bool,
     #[cfg_attr(
         feature = "non-posix",
@@ -207,6 +225,7 @@ pub struct Opts {
             env = "CRASHIE_SIGSTKFLT"
         )
     )]
+    #[cfg_attr(not(feature = "non-posix"), clap(skip))]
     pub sigstkflt: bool,
     #[cfg_attr(
         feature = "non-posix",
@@ -216,6 +235,7 @@ pub struct Opts {
             env = "CRASHIE_SIGCHLD"
         )
     )]
+    #[cfg_attr(not(feature = "non-posix"), clap(skip))]
     pub sigchld: bool,
     #[cfg_attr(
         feature = "non-posix",
@@ -225,6 +245,7 @@ pub struct Opts {
             env = "CRASHIE_SIGXCPU"
         )
     )]
+    #[cfg_attr(not(feature = "non-posix"), clap(skip))]
     pub sigxcpu: bool,
     #[cfg_attr(
         feature = "non-posix",
@@ -234,6 +255,7 @@ pub struct Opts {
             env = "CRASHIE_SIGXFSZ"
         )
     )]
+    #[cfg_attr(not(feature = "non-posix"), clap(skip))]
     pub sigxfsz: bool,
     #[cfg_attr(
         feature = "non-posix",
@@ -243,6 +265,7 @@ pub struct Opts {
             env = "CRASHIE_SIGVTALRM"
         )
     )]
+    #[cfg_attr(not(feature = "non-posix"), clap(skip))]
     pub sigvtalrm: bool,
     #[cfg_attr(
         feature = "non-posix",
@@ -252,11 +275,13 @@ pub struct Opts {
             env = "CRASHIE_SIGPROF"
         )
     )]
+    #[cfg_attr(not(feature = "non-posix"), clap(skip))]
     pub sigprof: bool,
     #[cfg_attr(
         feature = "non-posix",
         clap(long = "sigio", help = "I/O now possible", env = "CRASHIE_SIGIO")
     )]
+    #[cfg_attr(not(feature = "non-posix"), clap(skip))]
     pub sigio: bool,
     #[cfg_attr(
         feature = "non-posix",
@@ -266,16 +291,19 @@ pub struct Opts {
             env = "CRASHIE_SIGPOLL"
         )
     )]
+    #[cfg_attr(not(feature = "non-posix"), clap(skip))]
     pub sigpoll: bool,
     #[cfg_attr(
         feature = "non-posix",
         clap(long = "sigpwr", help = "Power supply failure", env = "CRASHIE_SIGPWR")
     )]
+    #[cfg_attr(not(feature = "non-posix"), clap(skip))]
     pub sigpwr: bool,
     #[cfg_attr(
         feature = "non-posix",
         clap(long = "sigsys", help = "Bad system call", env = "CRASHIE_SIGSYS")
     )]
+    #[cfg_attr(not(feature = "non-posix"), clap(skip))]
     pub sigsys: bool,
     #[cfg_attr(
         feature = "non-posix",
@@ -285,6 +313,7 @@ pub struct Opts {
             env = "CRASHIE_SIGUNUSED"
         )
     )]
+    #[cfg_attr(not(feature = "non-posix"), clap(skip))]
     pub sigunused: bool,
 }
 
@@ -306,7 +335,9 @@ fn parse_seconds(input: &str) -> Result<f64, String> {
     }
 }
 
+#[cfg(any(feature = "tcp-echo", feature = "udp-echo"))]
 fn parse_socket_addr(input: &str) -> Result<Vec<SocketAddr>, String> {
+    use std::net::ToSocketAddrs;
     Ok(input
         .to_socket_addrs()
         .map_err(|e| format!("{e}"))?

--- a/src/tcp_echo.rs
+++ b/src/tcp_echo.rs
@@ -1,0 +1,39 @@
+use std::io::{Read, Write};
+use std::net::{SocketAddr, TcpListener, TcpStream};
+use std::thread;
+
+pub fn tcp_echo(addr: &SocketAddr) -> Result<(), std::io::Error> {
+    let listener = TcpListener::bind(&addr)?;
+    println!("Listening for TCP connections on: {addr}");
+
+    thread::spawn(move || {
+        for stream in listener.incoming() {
+            match stream {
+                Ok(stream) => {
+                    println!(
+                        "Accepting TCP connection from {}",
+                        stream.peer_addr().expect("Unable to obtain peer address")
+                    );
+                    thread::spawn(move || handle_client(stream));
+                }
+                Err(e) => {
+                    eprintln!("Error accepting TCP connection: {e}");
+                }
+            }
+        }
+    });
+    Ok(())
+}
+
+fn handle_client(mut stream: TcpStream) {
+    let mut buffer = String::new();
+
+    match stream.read_to_string(&mut buffer) {
+        Ok(_) => {
+            stream.write_all(buffer.as_bytes()).unwrap();
+        }
+        Err(e) => {
+            eprintln!("Failed to read from socket: {}", e);
+        }
+    }
+}

--- a/src/tcp_echo.rs
+++ b/src/tcp_echo.rs
@@ -2,9 +2,32 @@ use std::io::{Read, Write};
 use std::net::{SocketAddr, TcpListener, TcpStream};
 use std::thread;
 
+/// Listens for TCP connections on the given address and spawns a new thread for each
+/// accepted connection.
+///
+/// # Arguments
+///
+/// * `addr` - The address to bind the TCP listener to.
+///
+/// # Examples
+///
+/// ```no_run
+/// use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+///
+/// let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8080);
+///
+/// if let Err(e) = tcp_echo(&addr) {
+///     eprintln!("Error occurred while running TCP echo server: {:?}", e);
+/// }
+/// ```
+///
+/// # Errors
+///
+/// This function returns an `std::io::Error` if there is an error binding the TCP listener to the
+/// given address, or if there is an error accepting a connection.
 pub fn tcp_echo(addr: &SocketAddr) -> Result<(), std::io::Error> {
-    let listener = TcpListener::bind(&addr)?;
-    println!("Listening for TCP connections on: {addr}");
+    let listener = TcpListener::bind(addr)?;
+    println!("Listening for TCP connections on {addr}");
 
     thread::spawn(move || {
         for stream in listener.incoming() {
@@ -25,6 +48,14 @@ pub fn tcp_echo(addr: &SocketAddr) -> Result<(), std::io::Error> {
     Ok(())
 }
 
+/// Handles the client connection and echoes the received data back.
+///
+/// This function reads data from the provided `TcpStream` and writes it back to the stream.
+/// It operates in a loop until the client closes the connection or an error occurs.
+///
+/// # Arguments
+///
+/// * `stream` - A `TcpStream` representing the client connection.
 fn handle_client(mut stream: TcpStream) {
     let mut buffer = [0; 512];
 

--- a/src/udp_echo.rs
+++ b/src/udp_echo.rs
@@ -1,0 +1,47 @@
+use std::net::{SocketAddr, UdpSocket};
+use std::thread;
+
+/// Listens for UDP datagrams on the given address and echoes each received datagram back to the sender.
+///
+/// # Arguments
+///
+/// * `addr` - The address to bind the UDP listener to.
+///
+/// # Examples
+///
+/// ```no_run
+/// use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+///
+/// let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8080);
+///
+/// if let Err(e) = udp_echo(&addr) {
+///     eprintln!("Error occurred while running UDP echo server: {:?}", e);
+/// }
+/// ```
+///
+/// # Errors
+///
+/// This function returns an `std::io::Error` if there is an error binding the UDP socket to the
+/// given address.
+pub fn udp_echo(addr: &SocketAddr) -> Result<(), std::io::Error> {
+    let socket = UdpSocket::bind(addr)?;
+    println!("Listening for UDP datagrams on {addr}");
+
+    thread::spawn(move || {
+        let mut buffer = [0; 512];
+
+        loop {
+            match socket.recv_from(&mut buffer) {
+                Ok((size, src)) => {
+                    if let Err(e) = socket.send_to(&buffer[0..size], src) {
+                        eprintln!("Failed to echo UDP datagram: {}", e);
+                    }
+                }
+                Err(e) => {
+                    eprintln!("Failed to receive UDP datagram: {}", e);
+                }
+            }
+        }
+    });
+    Ok(())
+}


### PR DESCRIPTION
This adds the `CRASHIE_BIND_TCP_ECHO` / `CRASHIE_BIND_UDP_ECHO` and `--bind-tcp-echo` / `--bind-udp-echo` echo arguments that bind crashie to the specified sockets and echoes back whatever is sent to them.