### PR TITLE
Add HTTP echo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Added echo support for UDP datagrams via the `CRASHIE_BIND_UDP_ECHO` / `--bind-udp-echo` option.
 - Added "echo" support for HTTP requests via the `CRASHIE_BIND_HTTP_ECHO` / `--bind-http-echo` option. The server
   will always respond with a `204 No Content`.
+- Added the `CRASHIE_HTTP_LIVENESS_PROBE_PATH` / `--http-liveness-probe-path` options to allow returning of
+  `200 OK` on a specific path.
 - Command-line options are now shown in named sections when using the `-h` / `--help` flag.
 
 ## [0.2.0] - 2024-01-07

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Added echo support for TCP connections via the `CRASHIE_BIND_TCP_ECHO` / `--bind-tcp-echo` option.
 - Added echo support for UDP datagrams via the `CRASHIE_BIND_UDP_ECHO` / `--bind-udp-echo` option.
+- Added "echo" support for HTTP requests via the `CRASHIE_BIND_HTTP_ECHO` / `--bind-http-echo` option. The server
+  will always respond with a `204 No Content`.
 - Command-line options are now shown in named sections when using the `-h` / `--help` flag.
 
 ## [0.2.0] - 2024-01-07

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,21 @@
 version = 3
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -57,10 +72,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "bumpalo"
+version = "3.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
+
+[[package]]
+name = "cc"
+version = "1.0.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "chrono"
+version = "0.4.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f2c685bad3eb3d45a01354cedb7d5faa66194d1d58ba6e267a8de788f79db38"
+dependencies = [
+ "android-tzdata",
+ "iana-time-zone",
+ "num-traits",
+ "windows-targets 0.48.5",
+]
 
 [[package]]
 name = "clap"
@@ -109,9 +151,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
+name = "core-foundation-sys"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
+
+[[package]]
 name = "crashie"
 version = "0.2.0"
 dependencies = [
+ "chrono",
  "clap",
  "dotenvy",
  "rand",
@@ -142,6 +191,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.59"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6a67363e2aa4443928ce15e57ebae94fd8949958fd1223c4cfc0cd473ad7539"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "js-sys"
+version = "0.3.66"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cee9c64da59eae3b50095c18d3e74f8b73c0b86d2792824ff01bbce68ba229ca"
+dependencies = [
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -154,6 +235,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
 
 [[package]]
+name = "log"
+version = "0.4.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
+
+[[package]]
 name = "num-traits"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -162,6 +249,12 @@ dependencies = [
  "autocfg",
  "libm",
 ]
+
+[[package]]
+name = "once_cell"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "ppv-lite86"
@@ -263,12 +356,90 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
+name = "wasm-bindgen"
+version = "0.2.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ed0d4f68a3015cc185aff4db9506a015f4b96f95303897bfa23f846db54064e"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b56f625e64f3a1084ded111c4d5f477df9f8c92df113852fa5a374dbda78826"
+dependencies = [
+ "bumpalo",
+ "log",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0162dbf37223cd2afce98f3d0785506dcb8d266223983e4b5b525859e6e182b2"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0eb82fcb7930ae6219a7ecfd55b217f5f0893484b7a13022ebb2b2bf20b5283"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ab9b36309365056cd639da3134bf87fa8f3d86008abf99e612384a6eecd459f"
+
+[[package]]
+name = "windows-core"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+dependencies = [
+ "windows-targets 0.52.0",
+]
+
+[[package]]
 name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.0",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -277,14 +448,20 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a18201040b24831fbb9e4eb208f8892e1f50a37feb53cc7ff887feb8f50e7cd"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.52.0",
+ "windows_aarch64_msvc 0.52.0",
+ "windows_i686_gnu 0.52.0",
+ "windows_i686_msvc 0.52.0",
+ "windows_x86_64_gnu 0.52.0",
+ "windows_x86_64_gnullvm 0.52.0",
+ "windows_x86_64_msvc 0.52.0",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -294,9 +471,21 @@ checksum = "cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -306,9 +495,21 @@ checksum = "a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -318,9 +519,21 @@ checksum = "3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,10 +12,11 @@ version = "0.2.0"
 edition = "2021"
 
 [features]
-default = ["posix", "non-posix", "tcp-echo", "udp-echo"]
+default = ["posix", "non-posix", "tcp-echo", "http-echo", "udp-echo"]
 posix = []
 non-posix = []
 tcp-echo = []
+http-echo = []
 udp-echo = []
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,10 +16,11 @@ default = ["posix", "non-posix", "tcp-echo", "http-echo", "udp-echo"]
 posix = []
 non-posix = []
 tcp-echo = []
-http-echo = []
+http-echo = ["dep:chrono"]
 udp-echo = []
 
 [dependencies]
+chrono = { version = "0.4.31", optional = true, default-features = false, features = ["clock", "alloc"] }
 clap = { version = "4.4.12", features = ["derive", "env"] }
 dotenvy = "0.15.7"
 rand = "0.8.5"

--- a/README.md
+++ b/README.md
@@ -43,6 +43,16 @@ crashie --bind-udp-echo 127.0.0.1:8080
 
 On Linux, you can test the echo behavior e.g. using netcat (`nc 127.0.0.1 8080` for TCP or `nc -u 127.0.0.1 8080` for UDP).
 
+To simplify work with HTTP connections, you can also bind an HTTP "echo". For that, use the `CRASHIE_BIND_HTTP_ECHO`
+environment variable or run e.g.
+
+```bash
+crashie --bind-http-echo 127.0.0.1:8080
+```
+
+You can test the connection e.g. with curl (`curl -v localhost:8080`). As of now, the server always ignores the request
+specifics and responds with `204 No Content`.
+
 ### Running via Docker
 
 The application is available as the [sunside/crashie](https://hub.docker.com/r/sunside/crashie) Docker image.

--- a/README.md
+++ b/README.md
@@ -53,6 +53,16 @@ crashie --bind-http-echo 127.0.0.1:8080
 You can test the connection e.g. with curl (`curl -v localhost:8080`). As of now, the server always ignores the request
 specifics and responds with `204 No Content`.
 
+To support cases where responses must be `200 OK` exactly - e.g. for liveness probes in ingress checks - you
+can provide the `CRASHIE_HTTP_LIVENESS_PROBE_PATH` or `--http-liveness-probe-path` argument:
+
+```bash
+crashie --bind-http-echo 127.0.0.1:8080 --http-liveness-probe-path /.health/livez
+```
+
+In this situation, calls to `curl -v localhost:8080` result in a `204 No Content`, while
+`curl -v localhost:8080/.health/livez` results in a `200 OK`.
+
 ### Running via Docker
 
 The application is available as the [sunside/crashie](https://hub.docker.com/r/sunside/crashie) Docker image.

--- a/src/http_echo.rs
+++ b/src/http_echo.rs
@@ -1,0 +1,66 @@
+use std::io::{BufRead, BufReader, Write};
+use std::net::{SocketAddr, TcpListener, TcpStream};
+use std::thread;
+
+pub fn http_echo(addr: &SocketAddr) -> Result<(), std::io::Error> {
+    let listener = TcpListener::bind(addr)?;
+    println!("Listening for HTTP connections on {addr}");
+
+    thread::spawn(move || {
+        for stream in listener.incoming() {
+            match stream {
+                Ok(stream) => {
+                    println!(
+                        "Accepting HTTP connection from {}",
+                        stream.peer_addr().expect("Unable to obtain peer address")
+                    );
+                    thread::spawn(move || handle_client(stream));
+                }
+                Err(e) => {
+                    eprintln!("Error accepting HTTP connection: {e}");
+                }
+            }
+        }
+    });
+    Ok(())
+}
+
+fn handle_client(stream: TcpStream) {
+    let mut reader = BufReader::new(stream);
+
+    loop {
+        let mut request_line = String::new();
+        if reader.read_line(&mut request_line).unwrap_or(0) == 0 {
+            return;
+        }
+
+        // RFC2616: should ignore any empty line(s) (CRLF only) received
+        // where a Request-Line is expected
+        if request_line == "\r\n" || request_line == "\n" {
+            continue;
+        }
+
+        // Reading headers
+        let mut header_line = String::new();
+        loop {
+            header_line.clear();
+            if reader.read_line(&mut header_line).unwrap_or(0) == 0 {
+                return;
+            }
+            if header_line == "\r\n" || header_line == "\n" {
+                break;
+            }
+        }
+
+        // To retain mutable reference to the stream after use
+        let mut stream = reader
+            .get_ref()
+            .try_clone()
+            .expect("Failed to obtain write stream");
+
+        let response = "HTTP/1.1 204 No Content\r\n\r\n";
+        if let Err(e) = stream.write_all(response.as_bytes()) {
+            eprintln!("Failed to write HTTP response: {e}")
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,7 @@
 //! crashie — when you need it to fail.
 
+#[cfg(feature = "http-echo")]
+mod http_echo;
 mod options;
 #[cfg(feature = "tcp-echo")]
 mod tcp_echo;
@@ -35,6 +37,15 @@ fn main() {
     for addr in opts.udp_echo_socks.iter().flatten() {
         if let Err(e) = udp_echo::udp_echo(addr) {
             eprintln!("Failed to bind to UDP socket: {e}");
+            exit(1);
+        }
+    }
+
+    // Bind HTTP sockets.
+    #[cfg(feature = "http-echo")]
+    for addr in opts.http_echo_socks.iter().flatten() {
+        if let Err(e) = http_echo::http_echo(addr) {
+            eprintln!("Failed to bind to HTTP socket: {e}");
             exit(1);
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,7 +44,7 @@ fn main() {
     // Bind HTTP sockets.
     #[cfg(feature = "http-echo")]
     for addr in opts.http_echo_socks.iter().flatten() {
-        if let Err(e) = http_echo::http_echo(addr) {
+        if let Err(e) = http_echo::http_echo(addr, opts.http_echo_liveness_probe_path.clone()) {
             eprintln!("Failed to bind to HTTP socket: {e}");
             exit(1);
         }

--- a/src/options.rs
+++ b/src/options.rs
@@ -3,6 +3,7 @@ use std::net::SocketAddr;
 
 const HELP_SECTION_CRASH_AFTER: &str = "Delay (crash after)";
 const HELP_SECTION_ECHO_SERVER: &str = "Echo Server";
+const HELP_SECTION_ECHO_SERVER_HTTP: &str = "Echo Server (HTTP)";
 const HELP_SECTION_EXIT_CODES: &str = "Exit Codes";
 const HELP_SECTION_EXIT_CODES_POSIX: &str = "Exit Codes (POSIX)";
 const HELP_SECTION_EXIT_CODES_NON_POSIX: &str = "Exit Codes (non-POSIX)";
@@ -66,7 +67,7 @@ pub struct Opts {
         feature = "http-echo",
         clap(
             long = "bind-http-echo",
-            help_heading = HELP_SECTION_ECHO_SERVER,
+            help_heading = HELP_SECTION_ECHO_SERVER_HTTP,
             help = "Provide HTTP echo on the specified addresses",
             value_name = "SOCK_ADDR",
             use_value_delimiter(true),
@@ -76,6 +77,20 @@ pub struct Opts {
     )]
     #[cfg_attr(not(feature = "http-echo"), clap(skip))]
     pub http_echo_socks: Vec<Vec<SocketAddr>>,
+    #[cfg_attr(
+        feature = "http-echo",
+        clap(
+            long = "http-liveness-probe-path",
+            help_heading = HELP_SECTION_ECHO_SERVER_HTTP,
+            help = "The request path on which to serve liveness probe results",
+            value_name = "HTTP_PATH",
+            use_value_delimiter(true),
+            default_value = "/health/live",
+            env = "CRASHIE_HTTP_LIVENESS_PROBE_PATH"
+        )
+    )]
+    #[cfg_attr(not(feature = "http-echo"), clap(skip))]
+    pub http_echo_liveness_probe_path: String,
 
     #[clap(
         short = 'e',

--- a/src/options.rs
+++ b/src/options.rs
@@ -33,6 +33,7 @@ pub struct Opts {
         env = "CRASHIE_SLEEP_DELAY_STDDEV"
     )]
     pub sleep_delay_stddev: f64,
+
     #[cfg_attr(
         feature = "tcp-echo",
         clap(
@@ -61,6 +62,21 @@ pub struct Opts {
     )]
     #[cfg_attr(not(feature = "udp-echo"), clap(skip))]
     pub udp_echo_socks: Vec<Vec<SocketAddr>>,
+    #[cfg_attr(
+        feature = "http-echo",
+        clap(
+            long = "bind-http-echo",
+            help_heading = HELP_SECTION_ECHO_SERVER,
+            help = "Provide HTTP echo on the specified addresses",
+            value_name = "SOCK_ADDR",
+            use_value_delimiter(true),
+            value_parser(parse_socket_addr),
+            env = "CRASHIE_BIND_HTTP_ECHO"
+        )
+    )]
+    #[cfg_attr(not(feature = "http-echo"), clap(skip))]
+    pub http_echo_socks: Vec<Vec<SocketAddr>>,
+
     #[clap(
         short = 'e',
         long = "exit-code",
@@ -83,6 +99,7 @@ pub struct Opts {
         env = "CRASHIE_SIGNALS"
     )]
     pub signal: Vec<u8>,
+
     #[cfg_attr(
         feature = "posix",
         clap(


### PR DESCRIPTION
- Added "echo" support for HTTP requests via the `CRASHIE_BIND_HTTP_ECHO` / `--bind-http-echo` option. The server
  will always respond with a `204 No Content`.
- Added the `CRASHIE_HTTP_LIVENESS_PROBE_PATH` / `--http-liveness-probe-path` options to allow returning of
  `200 OK` on a specific path. Defaults to `/health/live`.