### PR TITLE
Add grace period for delays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this project will be documented in this file.
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+- Added `CRASHIE_SLEEP_DELAY_GRACE_PERIOD` / `--delay-grace-period` option to provide a minimum value of seconds
+  to wait before crashing.
+
 ## [0.3.0] - 2024-01-06
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -158,7 +158,7 @@ checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
 
 [[package]]
 name = "crashie"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "chrono",
  "clap",

--- a/src/main.rs
+++ b/src/main.rs
@@ -50,6 +50,7 @@ fn main() {
         }
     }
 
+    let sleep_delay_grace = opts.sleep_delay_grace;
     let sleep_delay_mean = opts.sleep_delay;
     let sleep_delay_stddev = opts.sleep_delay_stddev;
     let mut codes = collect_exit_codes(opts);
@@ -61,11 +62,11 @@ fn main() {
     let exit_code = codes.choose(&mut rng).copied().expect("set was empty");
 
     // Sleep for a random duration.
-    let sleep_time = sample_random_sleep_duration(&mut rng, sleep_delay_mean, sleep_delay_stddev);
+    let sleep_time = sleep_delay_grace
+        + sample_random_sleep_duration(&mut rng, sleep_delay_mean, sleep_delay_stddev);
     if sleep_time >= 1e-6 {
-        println!("Sleeping for {sleep_time:.2} seconds, then exiting with code {exit_code}",);
-        let duration = Duration::from_secs_f64(sleep_time);
-        sleep(duration);
+        println!("Sleeping for {sleep_time:.2} seconds, then exiting with code {exit_code}");
+        sleep(Duration::from_secs_f64(sleep_time));
     }
 
     println!("Exiting with code {exit_code}");

--- a/src/options.rs
+++ b/src/options.rs
@@ -18,7 +18,7 @@ pub struct Opts {
         help = "The sleep duration before exiting, in seconds",
         value_name = "SECONDS",
         allow_negative_numbers = false,
-        default_value = "10.0",
+        default_value = "9.0",
         value_parser(parse_seconds),
         env = "CRASHIE_SLEEP_DELAY"
     )]
@@ -34,6 +34,17 @@ pub struct Opts {
         env = "CRASHIE_SLEEP_DELAY_STDDEV"
     )]
     pub sleep_delay_stddev: f64,
+    #[clap(
+        long = "delay-grace-period",
+        help_heading = HELP_SECTION_CRASH_AFTER,
+        help = "The duration, in seconds, to wait before starting the actual delay",
+        value_name = "SECONDS",
+        allow_negative_numbers = false,
+        default_value = "1.0",
+        value_parser(parse_seconds),
+        env = "CRASHIE_SLEEP_DELAY_GRACE_PERIOD"
+    )]
+    pub sleep_delay_grace: f64,
 
     #[cfg_attr(
         feature = "tcp-echo",


### PR DESCRIPTION
Added `CRASHIE_SLEEP_DELAY_GRACE_PERIOD` / `--delay-grace-period` option to provide a minimum value of seconds to wait before crashing.