### PR TITLE
Add --http-status flag, unit tests for pure helpers, and --help in README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   use case (restart-policy and probe testing).
 - GitHub Actions release workflow that publishes prebuilt binaries for Linux
   (x86_64, aarch64), macOS (x86_64, aarch64) and Windows (x86_64) on tag push.
+- Added `CRASHIE_HTTP_STATUS` / `--http-status` option to configure the HTTP status
+  code returned by the HTTP echo server for non-liveness paths (default `204`).
+  Useful for testing retry and circuit-breaker logic. The liveness probe path
+  continues to return `200 OK`.
+- README now includes the full `--help` output as a reference.
+- Unit tests for the pure helpers (`signal_to_exit`, `collect_exit_codes`,
+  `parse_signal`, `parse_seconds`, `parse_socket_addr`, `parse_http_status`)
+  and the HTTP response builder.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -98,6 +98,17 @@ In this situation, calls to `curl -v localhost:8080` result in a `204 No Content
 * Connection #0 to host localhost left intact
 ```
 
+The default status code for non-liveness paths is `204 No Content`. To make crashie return a
+different status (e.g. for testing retry and circuit-breaker logic), use `CRASHIE_HTTP_STATUS`
+or `--http-status`:
+
+```bash
+crashie --bind-http-echo 127.0.0.1:8080 --http-status 503
+```
+
+The liveness probe path continues to return `200 OK` regardless of the configured status,
+so probes still succeed while other paths fail.
+
 ### Running on Kubernetes
 
 A common use case for crashie is exercising a cluster's reaction to flaky pods — restart
@@ -197,4 +208,67 @@ To get a documentation, run
 
 ```shell
 cargo run -- --help
+```
+
+## All Command-Line Options
+
+Output of `crashie --help` (built with default features):
+
+```plain
+A Command-Line Utility that exits with a random exit code after a configurable delay
+
+Usage: crashie [OPTIONS]
+
+Options:
+  -h, --help     Print help
+  -V, --version  Print version
+
+Delay (crash after):
+  -d, --delay <SECONDS>               The sleep duration before exiting, in seconds [env: CRASHIE_SLEEP_DELAY=] [default: 9.0]
+      --delay-stddev <SECONDS>        The standard deviation of the sleep duration, in seconds [env: CRASHIE_SLEEP_DELAY_STDDEV=] [default: 2.0]
+      --delay-grace-period <SECONDS>  The duration, in seconds, to wait before starting the actual delay [env: CRASHIE_SLEEP_DELAY_GRACE_PERIOD=] [default: 1.0]
+
+Echo Server:
+      --bind-tcp-echo <SOCK_ADDR>  Provide TCP echo on the specified addresses [env: CRASHIE_BIND_TCP_ECHO=]
+      --bind-udp-echo <SOCK_ADDR>  Provide UDP echo on the specified addresses [env: CRASHIE_BIND_UDP_ECHO=]
+
+Echo Server (HTTP):
+      --bind-http-echo <SOCK_ADDR>            Provide HTTP echo on the specified addresses [env: CRASHIE_BIND_HTTP_ECHO=]
+      --http-liveness-probe-path <HTTP_PATH>  The request path on which to serve liveness probe results [env: CRASHIE_HTTP_LIVENESS_PROBE_PATH=] [default: /health/live]
+      --http-status <STATUS>                  Default HTTP status code returned for non-liveness paths [env: CRASHIE_HTTP_STATUS=] [default: 204]
+
+Exit Codes:
+  -e, --exit-code <EXIT_CODES>  Exit with the specified code(s) [env: CRASHIE_EXIT_CODES=]
+  -s, --signals <NUMBER>        Arbitrary signal (exit code 128+SIGNAL) [env: CRASHIE_SIGNALS=]
+
+Exit Codes (POSIX):
+      --sighup   Hang up controlling terminal or terminal [env: CRASHIE_SIGHUP=]
+      --sigint   Interrupt from keyboard, Control-C [env: CRASHIE_SIGINT=]
+      --sigquit  Quit from keyboard, Control-\ [env: CRASHIE_SIGQUIT=]
+      --sigill   Illegal instruction [env: CRASHIE_SIGILL=]
+      --sigabrt  Abnormal termination [env: CRASHIE_SIGABRT=]
+      --sigfpe   Floating-point exception [env: CRASHIE_SIGFPE=]
+      --sigkill  Forced process termination [env: CRASHIE_SIGKILL=]
+      --sigusr1  Freely available to processes [env: CRASHIE_SIGUSR1=]
+      --sigsegv  Invalid memory reference (Segmentation Fault) [env: CRASHIE_SIGSEGV=]
+      --sigusr2  Freely available to processes [env: CRASHIE_SIGUSR2=]
+      --sigpipe  Write to pipe with no readers [env: CRASHIE_SIGPIPE=]
+      --sigalrm  Real-time clock [env: CRASHIE_SIGALRM=]
+      --sigterm  Process termination [env: CRASHIE_SIGTERM=]
+
+Exit Codes (non-POSIX):
+      --sigtrap    Breakpoint for debugging [env: CRASHIE_SIGTRAP=]
+      --sigiot     Equivalent to SIGABRT [env: CRASHIE_SIGIOT=]
+      --sigbus     Bus error [env: CRASHIE_SIGBUS=]
+      --sigstkflt  Coprocessor stack error [env: CRASHIE_SIGSTKFLT=]
+      --sigchld    Child process stopped, terminated or got a signal if traced [env: CRASHIE_SIGCHLD=]
+      --sigxcpu    CPU time limit exceeded [env: CRASHIE_SIGXCPU=]
+      --sigxfsz    File size limit exceeded [env: CRASHIE_SIGXFSZ=]
+      --sigvtalrm  Virtual timer clock [env: CRASHIE_SIGVTALRM=]
+      --sigprof    Profile timer clock [env: CRASHIE_SIGPROF=]
+      --sigio      I/O now possible [env: CRASHIE_SIGIO=]
+      --sigpoll    Equivalent to SIGIO [env: CRASHIE_SIGPOLL=]
+      --sigpwr     Power supply failure [env: CRASHIE_SIGPWR=]
+      --sigsys     Bad system call [env: CRASHIE_SIGSYS=]
+      --sigunused  Equivalent to SIGSYS [env: CRASHIE_SIGUNUSED=]
 ```

--- a/src/http_echo.rs
+++ b/src/http_echo.rs
@@ -3,7 +3,11 @@ use std::io::{BufRead, BufReader, Write};
 use std::net::{SocketAddr, TcpListener, TcpStream};
 use std::thread;
 
-pub fn http_echo(addr: &SocketAddr, liveness_probe_path: String) -> Result<(), std::io::Error> {
+pub fn http_echo(
+    addr: &SocketAddr,
+    liveness_probe_path: String,
+    default_status: u16,
+) -> Result<(), std::io::Error> {
     let listener = TcpListener::bind(addr)?;
     println!("Listening for HTTP connections on {addr}");
 
@@ -16,7 +20,9 @@ pub fn http_echo(addr: &SocketAddr, liveness_probe_path: String) -> Result<(), s
                         stream.peer_addr().expect("Unable to obtain peer address")
                     );
                     let liveness_probe_path = liveness_probe_path.clone();
-                    thread::spawn(move || handle_client(stream, liveness_probe_path));
+                    thread::spawn(move || {
+                        handle_client(stream, liveness_probe_path, default_status)
+                    });
                 }
                 Err(e) => {
                     eprintln!("Error accepting HTTP connection: {e}");
@@ -27,7 +33,7 @@ pub fn http_echo(addr: &SocketAddr, liveness_probe_path: String) -> Result<(), s
     Ok(())
 }
 
-fn handle_client(stream: TcpStream, liveness_probe_path: String) {
+fn handle_client(stream: TcpStream, liveness_probe_path: String, default_status: u16) {
     let mut reader = BufReader::new(stream);
 
     loop {
@@ -63,21 +69,115 @@ fn handle_client(stream: TcpStream, liveness_probe_path: String) {
             .try_clone()
             .expect("Failed to obtain write stream");
 
-        // Setting version and date from env variable and system time respectively.
-        let version = env!("CARGO_PKG_VERSION");
         let date = Utc::now().format("%a, %d %b %Y %T GMT").to_string();
-
-        // Prepare response based on the request path
-        let response = if path == liveness_probe_path {
-            format!(
-                "HTTP/1.1 200 OK\r\nServer: crashie/{version}\r\nDate: {date}\r\nContent-Length: 0\r\nCache-Control: no-cache, no-store\r\n\r\n")
-        } else {
-            format!(
-                "HTTP/1.1 204 No Content\r\nServer: crashie/{version}\r\nDate: {date}\r\nContent-Length: 0\r\nCache-Control: no-cache, no-store\r\n\r\n")
-        };
+        let response = build_response(path, &liveness_probe_path, default_status, &date);
 
         if let Err(e) = stream.write_all(response.as_bytes()) {
             eprintln!("Failed to write HTTP response: {e}")
         }
+    }
+}
+
+fn build_response(
+    path: &str,
+    liveness_probe_path: &str,
+    default_status: u16,
+    date: &str,
+) -> String {
+    let version = env!("CARGO_PKG_VERSION");
+    let status = if path == liveness_probe_path {
+        200
+    } else {
+        default_status
+    };
+    let reason = reason_phrase(status);
+    format!(
+        "HTTP/1.1 {status} {reason}\r\nServer: crashie/{version}\r\nDate: {date}\r\nContent-Length: 0\r\nCache-Control: no-cache, no-store\r\n\r\n"
+    )
+}
+
+fn reason_phrase(status: u16) -> &'static str {
+    match status {
+        100 => "Continue",
+        101 => "Switching Protocols",
+        200 => "OK",
+        201 => "Created",
+        202 => "Accepted",
+        203 => "Non-Authoritative Information",
+        204 => "No Content",
+        205 => "Reset Content",
+        206 => "Partial Content",
+        300 => "Multiple Choices",
+        301 => "Moved Permanently",
+        302 => "Found",
+        303 => "See Other",
+        304 => "Not Modified",
+        307 => "Temporary Redirect",
+        308 => "Permanent Redirect",
+        400 => "Bad Request",
+        401 => "Unauthorized",
+        403 => "Forbidden",
+        404 => "Not Found",
+        405 => "Method Not Allowed",
+        408 => "Request Timeout",
+        409 => "Conflict",
+        410 => "Gone",
+        418 => "I'm a teapot",
+        422 => "Unprocessable Entity",
+        425 => "Too Early",
+        428 => "Precondition Required",
+        429 => "Too Many Requests",
+        431 => "Request Header Fields Too Large",
+        451 => "Unavailable For Legal Reasons",
+        500 => "Internal Server Error",
+        501 => "Not Implemented",
+        502 => "Bad Gateway",
+        503 => "Service Unavailable",
+        504 => "Gateway Timeout",
+        505 => "HTTP Version Not Supported",
+        507 => "Insufficient Storage",
+        511 => "Network Authentication Required",
+        _ => "Status",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const DATE: &str = "Sat, 06 Jan 2024 14:44:53 GMT";
+    const LIVENESS: &str = "/health/live";
+
+    #[test]
+    fn liveness_path_always_returns_200() {
+        let response = build_response(LIVENESS, LIVENESS, 503, DATE);
+        assert!(response.starts_with("HTTP/1.1 200 OK\r\n"));
+    }
+
+    #[test]
+    fn non_liveness_path_uses_default_status() {
+        let response = build_response("/anything", LIVENESS, 204, DATE);
+        assert!(response.starts_with("HTTP/1.1 204 No Content\r\n"));
+    }
+
+    #[test]
+    fn custom_status_is_used_for_non_liveness_path() {
+        let response = build_response("/api", LIVENESS, 503, DATE);
+        assert!(response.starts_with("HTTP/1.1 503 Service Unavailable\r\n"));
+    }
+
+    #[test]
+    fn unknown_status_falls_back_to_generic_reason() {
+        let response = build_response("/api", LIVENESS, 599, DATE);
+        assert!(response.starts_with("HTTP/1.1 599 Status\r\n"));
+    }
+
+    #[test]
+    fn response_includes_required_headers() {
+        let response = build_response("/api", LIVENESS, 200, DATE);
+        assert!(response.contains(&format!("Date: {DATE}\r\n")));
+        assert!(response.contains("Content-Length: 0\r\n"));
+        assert!(response.contains("Cache-Control: no-cache, no-store\r\n"));
+        assert!(response.ends_with("\r\n\r\n"));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,7 +45,11 @@ fn main() {
     // Bind HTTP sockets.
     #[cfg(feature = "http-echo")]
     for addr in opts.http_echo_socks.iter().flatten() {
-        if let Err(e) = http_echo::http_echo(addr, opts.http_echo_liveness_probe_path.clone()) {
+        if let Err(e) = http_echo::http_echo(
+            addr,
+            opts.http_echo_liveness_probe_path.clone(),
+            opts.http_echo_default_status,
+        ) {
             eprintln!("Failed to bind to HTTP socket: {e}");
             exit(1);
         }
@@ -176,4 +180,63 @@ fn add_signals(opts: Opts, codes: &mut HashSet<u8>) {
 
 const fn signal_to_exit(signal: u8) -> u8 {
     128 + signal
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::Parser;
+
+    #[test]
+    fn signal_to_exit_offsets_by_128() {
+        assert_eq!(signal_to_exit(1), 129);
+        assert_eq!(signal_to_exit(9), 137);
+        assert_eq!(signal_to_exit(15), 143);
+        assert_eq!(signal_to_exit(31), 159);
+    }
+
+    fn parse_opts(args: &[&str]) -> Opts {
+        let mut argv = vec!["crashie"];
+        argv.extend_from_slice(args);
+        Opts::try_parse_from(argv).expect("valid args")
+    }
+
+    #[test]
+    fn collect_exit_codes_returns_explicit_exit_codes() {
+        let opts = parse_opts(&["-e", "42,7"]);
+        let mut codes = collect_exit_codes(opts);
+        codes.sort();
+        assert_eq!(codes, vec![7, 42]);
+    }
+
+    #[cfg(feature = "posix")]
+    #[test]
+    fn collect_exit_codes_converts_signals() {
+        let opts = parse_opts(&["--sigint", "--sigkill"]);
+        let mut codes = collect_exit_codes(opts);
+        codes.sort();
+        assert_eq!(codes, vec![130, 137]);
+    }
+
+    #[cfg(all(feature = "posix", feature = "non-posix"))]
+    #[test]
+    fn collect_exit_codes_deduplicates_overlapping_inputs() {
+        // SIGABRT and SIGIOT both map to exit code 134.
+        let opts = parse_opts(&["--sigabrt", "--sigiot"]);
+        let codes = collect_exit_codes(opts);
+        assert_eq!(codes, vec![134]);
+    }
+
+    #[test]
+    fn collect_exit_codes_is_empty_when_no_codes_or_signals() {
+        let opts = parse_opts(&[]);
+        assert!(collect_exit_codes(opts).is_empty());
+    }
+
+    #[test]
+    fn sample_random_sleep_duration_is_mean_when_stddev_is_zero() {
+        let mut rng = rand::rng();
+        let sample = sample_random_sleep_duration(&mut rng, 5.0, 0.0);
+        assert!((sample - 5.0).abs() < 1e-9);
+    }
 }

--- a/src/options.rs
+++ b/src/options.rs
@@ -102,6 +102,20 @@ pub struct Opts {
     )]
     #[cfg_attr(not(feature = "http-echo"), clap(skip))]
     pub http_echo_liveness_probe_path: String,
+    #[cfg_attr(
+        feature = "http-echo",
+        clap(
+            long = "http-status",
+            help_heading = HELP_SECTION_ECHO_SERVER_HTTP,
+            help = "Default HTTP status code returned for non-liveness paths",
+            value_name = "STATUS",
+            default_value = "204",
+            value_parser(parse_http_status),
+            env = "CRASHIE_HTTP_STATUS"
+        )
+    )]
+    #[cfg_attr(not(feature = "http-echo"), clap(skip))]
+    pub http_echo_default_status: u16,
 
     #[clap(
         short = 'e',
@@ -443,11 +457,98 @@ fn parse_seconds(input: &str) -> Result<f64, String> {
     }
 }
 
-#[cfg(any(feature = "tcp-echo", feature = "udp-echo"))]
+#[cfg(any(feature = "tcp-echo", feature = "udp-echo", feature = "http-echo"))]
 fn parse_socket_addr(input: &str) -> Result<Vec<SocketAddr>, String> {
     use std::net::ToSocketAddrs;
     Ok(input
         .to_socket_addrs()
         .map_err(|e| format!("{e}"))?
         .collect())
+}
+
+#[cfg(feature = "http-echo")]
+fn parse_http_status(input: &str) -> Result<u16, String> {
+    let value: u16 = input.parse().map_err(|e| format!("{e}"))?;
+    if !(100..=599).contains(&value) {
+        Err(String::from(
+            "HTTP status code must be in range 100 to 599 (inclusive)",
+        ))
+    } else {
+        Ok(value)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_seconds_accepts_positive() {
+        assert_eq!(parse_seconds("1.5"), Ok(1.5));
+        assert_eq!(parse_seconds("0"), Ok(0.0));
+    }
+
+    #[test]
+    fn parse_seconds_rejects_negative() {
+        assert!(parse_seconds("-0.5").is_err());
+    }
+
+    #[test]
+    fn parse_seconds_rejects_garbage() {
+        assert!(parse_seconds("not-a-number").is_err());
+    }
+
+    #[test]
+    fn parse_signal_accepts_in_range() {
+        assert_eq!(parse_signal("1"), Ok(1));
+        assert_eq!(parse_signal("15"), Ok(15));
+        assert_eq!(parse_signal("31"), Ok(31));
+    }
+
+    #[test]
+    fn parse_signal_rejects_out_of_range() {
+        assert!(parse_signal("0").is_err());
+        assert!(parse_signal("32").is_err());
+        assert!(parse_signal("255").is_err());
+    }
+
+    #[test]
+    fn parse_signal_rejects_garbage() {
+        assert!(parse_signal("KILL").is_err());
+    }
+
+    #[cfg(any(feature = "tcp-echo", feature = "udp-echo", feature = "http-echo"))]
+    #[test]
+    fn parse_socket_addr_accepts_ipv4() {
+        let addrs = parse_socket_addr("127.0.0.1:8080").expect("valid IPv4");
+        assert!(!addrs.is_empty());
+        assert_eq!(addrs[0].port(), 8080);
+    }
+
+    #[cfg(any(feature = "tcp-echo", feature = "udp-echo", feature = "http-echo"))]
+    #[test]
+    fn parse_socket_addr_rejects_garbage() {
+        assert!(parse_socket_addr("not a socket").is_err());
+    }
+
+    #[cfg(feature = "http-echo")]
+    #[test]
+    fn parse_http_status_accepts_valid_codes() {
+        assert_eq!(parse_http_status("200"), Ok(200));
+        assert_eq!(parse_http_status("204"), Ok(204));
+        assert_eq!(parse_http_status("503"), Ok(503));
+    }
+
+    #[cfg(feature = "http-echo")]
+    #[test]
+    fn parse_http_status_rejects_out_of_range() {
+        assert!(parse_http_status("99").is_err());
+        assert!(parse_http_status("600").is_err());
+    }
+
+    #[cfg(feature = "http-echo")]
+    #[test]
+    fn parse_http_status_rejects_garbage() {
+        assert!(parse_http_status("OK").is_err());
+    }
 }


### PR DESCRIPTION
## Summary

Follow-ups from #10 — the three items listed as "not done" in that PR's summary.

### `--http-status` flag

Adds `CRASHIE_HTTP_STATUS` / `--http-status` (default `204`) which sets the HTTP status code returned by the echo server for non-liveness paths. Useful for testing retry/circuit-breaker logic in upstream callers — a service that returns `503` for "real" requests but `200` for liveness probes is now a one-liner:

```bash
crashie --bind-http-echo 127.0.0.1:8080 --http-status 503
```

The liveness probe path keeps returning `200 OK` regardless, so probes still succeed while other paths fail. Response generation is extracted into a pure `build_response` helper and a small reason-phrase lookup keeps the status line well-formed; unknown codes fall back to `"Status"`. Status codes are validated to be in `100..=599`.

End-to-end verified:
```
$ curl -s -i http://127.0.0.1:18081/ | head -2
HTTP/1.1 503 Service Unavailable
Server: crashie/0.4.0
$ curl -s -i http://127.0.0.1:18081/health/live | head -2
HTTP/1.1 200 OK
Server: crashie/0.4.0
```

### Unit tests for pure helpers

22 tests total, covering:
- `signal_to_exit` (128+SIGNAL offset)
- `collect_exit_codes` (explicit codes, signal flags, dedup of overlapping aliases like SIGABRT/SIGIOT, empty case)
- `sample_random_sleep_duration` with `stddev = 0` returns the mean
- `parse_signal`, `parse_seconds`, `parse_socket_addr`, `parse_http_status` (happy paths + rejection cases)
- `build_response` (liveness override, custom status, unknown-status fallback, required headers)

Signal-dependent tests are gated on the `posix` / `non-posix` features, so `cargo test --no-default-features` (10 tests) and `cargo test --all-features` (22 tests) both pass.

### `--help` snippet in README

Adds an "All Command-Line Options" section at the end of the README reproducing the full `--help` output, so people can scan the flags without installing crashie.

## Test plan

- [x] `cargo test --all-features --release` → 22 passed
- [x] `cargo test --no-default-features --release` → 10 passed
- [x] `cargo clippy --all-features --release -- -D warnings` → clean
- [x] `rustfmt --check` → clean
- [x] Manual: HTTP echo with `--http-status 503` returns `503` on `/`, `200` on `/health/live`, then exits with configured code


---
_Generated by [Claude Code](https://claude.ai/code/session_01HAqUrCaTUa9iKctz5cW9Ze)_