### PR TITLE
Cut 0.5.0: rotating --http-status, multi-arch Docker, MSRV, badges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,8 +29,10 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Changed
 
 - Upgraded `rand` from `0.8.5` to `0.9.3` and `rand_distr` from `0.4.3` to `0.5`.
-- Docker base images bumped to `rust:1.85-alpine3.21` (builder) and
-  `alpine:3.21` (runtime). The release build now uses `--locked`.
+- Docker base images bumped to `rust:1.91-alpine3.21` (builder) and
+  `alpine:3.21` (runtime). The release build now uses `--locked`, and
+  `cargo install cargo-auditable` is also pinned with `--locked` so a
+  newer transitive dep of `cargo-auditable` can't break the image build.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-05-22
+
 ### Added
 
 - README now includes a Kubernetes Deployment example demonstrating the intended
@@ -12,10 +14,14 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - GitHub Actions release workflow that publishes prebuilt binaries for Linux
   (x86_64, aarch64), macOS (x86_64, aarch64) and Windows (x86_64) on tag push.
 - Added `CRASHIE_HTTP_STATUS` / `--http-status` option to configure the HTTP status
-  code returned by the HTTP echo server for non-liveness paths (default `204`).
-  Useful for testing retry and circuit-breaker logic. The liveness probe path
-  continues to return `200 OK`.
-- README now includes the full `--help` output as a reference.
+  code(s) returned by the HTTP echo server for non-liveness paths (default `204`).
+  Accepts a comma-separated list to rotate through statuses at random per request,
+  useful for chaos / flake-tolerance testing. The liveness probe path continues to
+  return `200 OK`.
+- README now includes the full `--help` output and a badge row.
+- Declared a minimum supported Rust version (MSRV) of `1.75`.
+- `build-docker.sh` now uses `docker buildx` and supports multi-arch builds
+  (`linux/amd64` and `linux/arm64` by default); set `PUSH=1` to publish.
 - Unit tests for the pure helpers (`signal_to_exit`, `collect_exit_codes`,
   `parse_signal`, `parse_seconds`, `parse_socket_addr`, `parse_http_status`)
   and the HTTP response builder.
@@ -23,6 +29,8 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Changed
 
 - Upgraded `rand` from `0.8.5` to `0.9.3` and `rand_distr` from `0.4.3` to `0.5`.
+- Docker base images bumped to `rust:1.85-alpine3.21` (builder) and
+  `alpine:3.21` (runtime). The release build now uses `--locked`.
 
 ### Fixed
 
@@ -71,7 +79,8 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - 🎉 Initial release.
 
-[Unreleased]: https://github.com/sunsided/crashie/compare/0.4.0...HEAD
+[Unreleased]: https://github.com/sunsided/crashie/compare/0.5.0...HEAD
+[0.5.0]: https://github.com/sunsided/crashie/releases/tag/0.5.0
 [0.4.0]: https://github.com/sunsided/crashie/releases/tag/0.4.0
 [0.3.0]: https://github.com/sunsided/crashie/releases/tag/0.3.0
 [0.2.0]: https://github.com/sunsided/crashie/releases/tag/0.2.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -159,7 +159,7 @@ checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
 
 [[package]]
 name = "crashie"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,8 +8,9 @@ keywords = ["cli", "docker"]
 categories = ["command-line-utilities"]
 license = "EUPL-1.2"
 readme = "README.md"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
+rust-version = "1.75"
 
 [features]
 default = ["posix", "non-posix", "tcp-echo", "http-echo", "udp-echo"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM rust:1.85-alpine3.21 AS builder
+FROM rust:1.91-alpine3.21 AS builder
 ENV RUSTFLAGS="-C target-feature=-crt-static"
 RUN apk add --no-cache musl-dev
-RUN cargo install cargo-auditable
+RUN cargo install --locked cargo-auditable
 WORKDIR /app
 COPY ./ /app
 RUN cargo auditable build --release --locked

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,13 @@
-FROM rust:1.75-alpine3.19 AS builder
+FROM rust:1.85-alpine3.21 AS builder
 ENV RUSTFLAGS="-C target-feature=-crt-static"
 RUN apk add --no-cache musl-dev
 RUN cargo install cargo-auditable
 WORKDIR /app
 COPY ./ /app
-RUN cargo auditable build --release
+RUN cargo auditable build --release --locked
 RUN strip target/release/crashie
 
-FROM alpine:3.19
+FROM alpine:3.21
 RUN apk add --no-cache libgcc
 WORKDIR /app
 COPY --from=builder /app/target/release/crashie .

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # 💥 crashie — a little failure in a box
 
+[![crates.io](https://img.shields.io/crates/v/crashie.svg)](https://crates.io/crates/crashie)
+[![Docker Pulls](https://img.shields.io/docker/pulls/sunside/crashie.svg)](https://hub.docker.com/r/sunside/crashie)
+[![Rust](https://github.com/sunsided/crashie/actions/workflows/rust.yml/badge.svg)](https://github.com/sunsided/crashie/actions/workflows/rust.yml)
+[![License: EUPL-1.2](https://img.shields.io/badge/License-EUPL_1.2-blue.svg)](LICENSE.md)
+
 Crashie is a Command-Line Utility that exits with a random exit code after a configurable delay. Use it when you
 want to test restart behaviors or anything that requires an application to fail.
 
@@ -104,6 +109,13 @@ or `--http-status`:
 
 ```bash
 crashie --bind-http-echo 127.0.0.1:8080 --http-status 503
+```
+
+Pass a comma-separated list to rotate through statuses at random per request — handy for
+exercising chaos / flake tolerance in upstream callers:
+
+```bash
+crashie --bind-http-echo 127.0.0.1:8080 --http-status 200,500,503
 ```
 
 The liveness probe path continues to return `200 OK` regardless of the configured status,
@@ -235,7 +247,7 @@ Echo Server:
 Echo Server (HTTP):
       --bind-http-echo <SOCK_ADDR>            Provide HTTP echo on the specified addresses [env: CRASHIE_BIND_HTTP_ECHO=]
       --http-liveness-probe-path <HTTP_PATH>  The request path on which to serve liveness probe results [env: CRASHIE_HTTP_LIVENESS_PROBE_PATH=] [default: /health/live]
-      --http-status <STATUS>                  Default HTTP status code returned for non-liveness paths [env: CRASHIE_HTTP_STATUS=] [default: 204]
+      --http-status <STATUS>                  HTTP status code(s) returned for non-liveness paths. Pass multiple to pick one at random per request [env: CRASHIE_HTTP_STATUS=] [default: 204]
 
 Exit Codes:
   -e, --exit-code <EXIT_CODES>  Exit with the specified code(s) [env: CRASHIE_EXIT_CODES=]

--- a/build-docker.sh
+++ b/build-docker.sh
@@ -3,22 +3,60 @@ set -euo pipefail
 
 DOCKER_IMAGE=sunside/crashie
 DOCKER_URL="https://hub.docker.com/r/$DOCKER_IMAGE"
+PLATFORMS="${PLATFORMS:-linux/amd64,linux/arm64}"
+PUSH="${PUSH:-0}"
 
 BUILD_DATE=$(date --rfc-3339=seconds | sed 's/ /T/')
 GIT_COMMIT_HASH=$(git rev-parse HEAD)
 APP_VERSION=$(sed -n 's/^version = "\(\S*\)\"$/\1/p' Cargo.toml)
 
-docker build --progress=plain --tag "$DOCKER_IMAGE" \
-  --label org.opencontainers.image.base.name="$DOCKER_IMAGE" \
-  --label org.opencontainers.image.url="$DOCKER_URL" \
-  --label org.opencontainers.artifact.created="$BUILD_DATE" \
-  --label org.opencontainers.image.created="$BUILD_DATE" \
-  --label org.opencontainers.image.authors="Markus Mayer" \
-  --label org.opencontainers.image.revision="$GIT_COMMIT_HASH" \
-  --label org.opencontainers.image.version="$APP_VERSION" \
-  -f Dockerfile .
+# Multi-arch builds require a buildx builder with QEMU emulation. Create one if
+# the default doesn't already exist.
+if ! docker buildx inspect crashie-builder >/dev/null 2>&1; then
+  echo "Creating buildx builder 'crashie-builder' for platforms: $PLATFORMS"
+  docker buildx create --name crashie-builder --driver docker-container --use >/dev/null
+  docker buildx inspect --bootstrap >/dev/null
+else
+  docker buildx use crashie-builder >/dev/null
+fi
 
-echo "Tagging image $DOCKER_IMAGE:latest as $DOCKER_IMAGE:$APP_VERSION"
-docker tag "$DOCKER_IMAGE:latest" "$DOCKER_IMAGE:$APP_VERSION"
+# Multi-arch images can only be pushed (or saved to a tar); --load works for a
+# single platform only. When PUSH=0 we fall back to the host platform so the
+# resulting image is usable locally.
+if [[ "$PUSH" == "1" ]]; then
+  OUTPUT_FLAGS=(--push)
+else
+  OUTPUT_FLAGS=(--load)
+  if [[ "$PLATFORMS" == *","* ]]; then
+    echo "PUSH=0: --load only supports one platform; building for the host platform only."
+    PLATFORMS=""
+  fi
+fi
 
-echo "Inspect labels using docker inspect $DOCKER_IMAGE:$APP_VERSION"
+BUILD_ARGS=(
+  --progress=plain
+  --label "org.opencontainers.image.base.name=$DOCKER_IMAGE"
+  --label "org.opencontainers.image.url=$DOCKER_URL"
+  --label "org.opencontainers.artifact.created=$BUILD_DATE"
+  --label "org.opencontainers.image.created=$BUILD_DATE"
+  --label "org.opencontainers.image.authors=Markus Mayer"
+  --label "org.opencontainers.image.revision=$GIT_COMMIT_HASH"
+  --label "org.opencontainers.image.version=$APP_VERSION"
+  --tag "$DOCKER_IMAGE:latest"
+  --tag "$DOCKER_IMAGE:$APP_VERSION"
+  "${OUTPUT_FLAGS[@]}"
+)
+
+if [[ -n "$PLATFORMS" ]]; then
+  BUILD_ARGS+=(--platform "$PLATFORMS")
+fi
+
+docker buildx build "${BUILD_ARGS[@]}" -f Dockerfile .
+
+echo "Built $DOCKER_IMAGE:$APP_VERSION (also tagged as :latest)"
+if [[ "$PUSH" == "1" ]]; then
+  echo "Pushed to $DOCKER_URL"
+else
+  echo "Inspect labels using: docker inspect $DOCKER_IMAGE:$APP_VERSION"
+  echo "Run 'PUSH=1 $0' to publish multi-arch images to Docker Hub."
+fi

--- a/src/http_echo.rs
+++ b/src/http_echo.rs
@@ -1,15 +1,23 @@
 use chrono::prelude::*;
+use rand::prelude::*;
 use std::io::{BufRead, BufReader, Write};
 use std::net::{SocketAddr, TcpListener, TcpStream};
+use std::sync::Arc;
 use std::thread;
 
 pub fn http_echo(
     addr: &SocketAddr,
     liveness_probe_path: String,
-    default_status: u16,
+    default_statuses: Vec<u16>,
 ) -> Result<(), std::io::Error> {
     let listener = TcpListener::bind(addr)?;
     println!("Listening for HTTP connections on {addr}");
+
+    let statuses: Arc<[u16]> = if default_statuses.is_empty() {
+        Arc::from(vec![204])
+    } else {
+        Arc::from(default_statuses)
+    };
 
     thread::spawn(move || {
         for stream in listener.incoming() {
@@ -20,9 +28,8 @@ pub fn http_echo(
                         stream.peer_addr().expect("Unable to obtain peer address")
                     );
                     let liveness_probe_path = liveness_probe_path.clone();
-                    thread::spawn(move || {
-                        handle_client(stream, liveness_probe_path, default_status)
-                    });
+                    let statuses = Arc::clone(&statuses);
+                    thread::spawn(move || handle_client(stream, liveness_probe_path, &statuses));
                 }
                 Err(e) => {
                     eprintln!("Error accepting HTTP connection: {e}");
@@ -33,7 +40,8 @@ pub fn http_echo(
     Ok(())
 }
 
-fn handle_client(stream: TcpStream, liveness_probe_path: String, default_status: u16) {
+fn handle_client(stream: TcpStream, liveness_probe_path: String, default_statuses: &[u16]) {
+    let mut rng = rand::rng();
     let mut reader = BufReader::new(stream);
 
     loop {
@@ -70,7 +78,14 @@ fn handle_client(stream: TcpStream, liveness_probe_path: String, default_status:
             .expect("Failed to obtain write stream");
 
         let date = Utc::now().format("%a, %d %b %Y %T GMT").to_string();
-        let response = build_response(path, &liveness_probe_path, default_status, &date);
+        let status = if path == liveness_probe_path {
+            200
+        } else {
+            *default_statuses
+                .choose(&mut rng)
+                .expect("default_statuses is non-empty")
+        };
+        let response = build_response(status, &date);
 
         if let Err(e) = stream.write_all(response.as_bytes()) {
             eprintln!("Failed to write HTTP response: {e}")
@@ -78,18 +93,8 @@ fn handle_client(stream: TcpStream, liveness_probe_path: String, default_status:
     }
 }
 
-fn build_response(
-    path: &str,
-    liveness_probe_path: &str,
-    default_status: u16,
-    date: &str,
-) -> String {
+fn build_response(status: u16, date: &str) -> String {
     let version = env!("CARGO_PKG_VERSION");
-    let status = if path == liveness_probe_path {
-        200
-    } else {
-        default_status
-    };
     let reason = reason_phrase(status);
     format!(
         "HTTP/1.1 {status} {reason}\r\nServer: crashie/{version}\r\nDate: {date}\r\nContent-Length: 0\r\nCache-Control: no-cache, no-store\r\n\r\n"
@@ -144,40 +149,46 @@ fn reason_phrase(status: u16) -> &'static str {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::HashSet;
 
     const DATE: &str = "Sat, 06 Jan 2024 14:44:53 GMT";
-    const LIVENESS: &str = "/health/live";
 
     #[test]
-    fn liveness_path_always_returns_200() {
-        let response = build_response(LIVENESS, LIVENESS, 503, DATE);
+    fn build_response_emits_known_reason_phrase() {
+        let response = build_response(200, DATE);
         assert!(response.starts_with("HTTP/1.1 200 OK\r\n"));
     }
 
     #[test]
-    fn non_liveness_path_uses_default_status() {
-        let response = build_response("/anything", LIVENESS, 204, DATE);
-        assert!(response.starts_with("HTTP/1.1 204 No Content\r\n"));
-    }
-
-    #[test]
-    fn custom_status_is_used_for_non_liveness_path() {
-        let response = build_response("/api", LIVENESS, 503, DATE);
+    fn build_response_emits_custom_status() {
+        let response = build_response(503, DATE);
         assert!(response.starts_with("HTTP/1.1 503 Service Unavailable\r\n"));
     }
 
     #[test]
-    fn unknown_status_falls_back_to_generic_reason() {
-        let response = build_response("/api", LIVENESS, 599, DATE);
+    fn build_response_falls_back_to_generic_reason() {
+        let response = build_response(599, DATE);
         assert!(response.starts_with("HTTP/1.1 599 Status\r\n"));
     }
 
     #[test]
-    fn response_includes_required_headers() {
-        let response = build_response("/api", LIVENESS, 200, DATE);
+    fn build_response_includes_required_headers() {
+        let response = build_response(200, DATE);
         assert!(response.contains(&format!("Date: {DATE}\r\n")));
         assert!(response.contains("Content-Length: 0\r\n"));
         assert!(response.contains("Cache-Control: no-cache, no-store\r\n"));
         assert!(response.ends_with("\r\n\r\n"));
+    }
+
+    #[test]
+    fn random_status_selection_only_picks_from_the_configured_set() {
+        let statuses = [200u16, 500, 503];
+        let allowed: HashSet<u16> = statuses.iter().copied().collect();
+        let mut rng = rand::rng();
+
+        for _ in 0..200 {
+            let picked = *statuses.choose(&mut rng).unwrap();
+            assert!(allowed.contains(&picked));
+        }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,7 +48,7 @@ fn main() {
         if let Err(e) = http_echo::http_echo(
             addr,
             opts.http_echo_liveness_probe_path.clone(),
-            opts.http_echo_default_status,
+            opts.http_echo_default_status.clone(),
         ) {
             eprintln!("Failed to bind to HTTP socket: {e}");
             exit(1);

--- a/src/options.rs
+++ b/src/options.rs
@@ -107,15 +107,16 @@ pub struct Opts {
         clap(
             long = "http-status",
             help_heading = HELP_SECTION_ECHO_SERVER_HTTP,
-            help = "Default HTTP status code returned for non-liveness paths",
+            help = "HTTP status code(s) returned for non-liveness paths. Pass multiple to pick one at random per request",
             value_name = "STATUS",
+            use_value_delimiter(true),
             default_value = "204",
             value_parser(parse_http_status),
             env = "CRASHIE_HTTP_STATUS"
         )
     )]
     #[cfg_attr(not(feature = "http-echo"), clap(skip))]
-    pub http_echo_default_status: u16,
+    pub http_echo_default_status: Vec<u16>,
 
     #[clap(
         short = 'e',


### PR DESCRIPTION
## Summary

Release prep for `0.5.0` plus the follow-up items from the recent discussion.

### Random HTTP status rotation
`--http-status` / `CRASHIE_HTTP_STATUS` now accepts a comma-separated list. When more than one code is configured, the HTTP echo server picks one uniformly at random per incoming request — mirroring how `-e` / `-s` already work and giving you a one-flag chaos endpoint:
```bash
crashie --bind-http-echo 127.0.0.1:8080 --http-status 200,500,503
```
The liveness probe path keeps returning `200 OK` regardless, so probes still succeed while real traffic flakes. Backward compatible — a single value still works exactly as before.

Smoke-tested locally — 8 hits to `/` returned a mix of `200`/`500`/`503`; `/health/live` returned `200`.

### Docker refresh + multi-arch
- `Dockerfile`: builder bumped to `rust:1.85-alpine3.21`, runtime to `alpine:3.21` (the old `1.75-alpine3.19` pair was ~18 months stale). The in-image cargo build now uses `--locked` so the published image always matches `Cargo.lock`.
- `build-docker.sh`: switched to `docker buildx` with `linux/amd64,linux/arm64` defaults. `PUSH=1` publishes a multi-arch manifest to Docker Hub; without it, the script falls back to a single-platform `--load` so local `docker run` keeps working. `PLATFORMS=...` overrides.

I couldn't actually run the Docker build in this environment (no daemon), so please give it a smoke test before merging.

### Release polish
- `Cargo.toml`: version → `0.5.0`, declared `rust-version = "1.75"` (within rand 0.9's 1.63 floor and clap 4's 1.74 floor; matches what the Dockerfile already required).
- README badge row: crates.io, Docker Pulls, CI status, license.
- `--help` snippet and `--http-status` docs updated for the rotation behavior.
- `CHANGELOG.md`: moved the accumulated Unreleased entries into a dated `0.5.0` release and added the new items.
- Existing dependabot PR #9 (rand 0.8 → 0.9) closed with a pointer to #10.

After merge, push the `0.5.0` tag to trigger the release workflow (which will produce the prebuilt binaries from #10).

## Test plan

- [x] `cargo build --release`
- [x] `cargo test --all-features --release` → 22 passed
- [x] `cargo test --no-default-features --release` → 10 passed
- [x] `cargo clippy --all-features --release -- -D warnings` → clean
- [x] `rustfmt --check` → clean
- [x] Manual: `--http-status 200,500,503` rotates statuses on `/` and keeps `/health/live` at 200
- [x] `bash -n build-docker.sh` (syntax)
- [ ] Manual: `bash build-docker.sh` against a real Docker daemon
- [ ] Push `0.5.0` tag to trigger release workflow and confirm prebuilt binaries land


---
_Generated by [Claude Code](https://claude.ai/code/session_01HAqUrCaTUa9iKctz5cW9Ze)_